### PR TITLE
[Plugin Parsing] Updates the plugin parsing of the scenery builder to support the new "Plugin.json" metamodel, and the new floorplan_model folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,34 @@ This module adds `floorplan` as a command line interface. You can use the `gener
 floorplan generate <path to config file> <path to input folder>
 ```
 
-Where the input folder must contain:
-- the composable models generated from the [FloorPlan DSL](https://github.com/secorolab/FloorPlan-DSL)
+for example: 
+
+```shell
+floorplan generate <path_to_workspace>/src/scenery_builder/config/config.toml -i <path_to_workspace>/src/floorplan_models/frontiers_brsu_building_c/models/
+```
+
+Where the input folder must contain two subfolders:
+- one folder containing the composable models generated from the [FloorPlan DSL](https://github.com/secorolab/FloorPlan-DSL)
     - `coordinate.json`
     - `floorplan.json`
     - `shape.json`
     - `skeleton.json`
     - `spatial_relations.json`
-- the door object models
+- one folder containing the door plugins, the door object models, and their specific instances 
     - `object-door.json`
     - `object-door-states.json`
-- any object instance models, e.g. `object-door-instance-X.json` where `X` is a unique numeric ID.
+    - `initial-state-plugin-states.json`
+    - `dynamic-plugin-states.json`
+    - `adversarial-plugin-states.json`
+    - any object instance models, e.g. `object-door-instance-X.json` where `X` is a unique numeric ID.
+
+if any of these json files contain `localhost:8000` link in its context, for example `"http://localhost:8000/floor-plan/plugin.json`,
+it is probably because we have not gotten around to hosting that file yet, or forgot to update the link. In that case, locate
+the file inside our repositories (probably [metamodels](https://github.com/secorolab/metamodels)), navigate to the root of the cloned repository, and run:
+
+```shell
+python3 -m http.server 8000
+```
 
 ## Task generator
 

--- a/src/fpm/constants.py
+++ b/src/fpm/constants.py
@@ -6,6 +6,7 @@ from pathlib import Path
 FP = rdflib.Namespace("https://secorolab.github.io/metamodels/floorplan#")
 OBJ = rdflib.Namespace("https://secorolab.github.io/metamodels/object#")
 ST = rdflib.Namespace("https://secorolab.github.io/metamodels/state#")
+PL = rdflib.Namespace("https://secorolab.github.io/metamodels/plugin#")
 
 # Kinematic chain metamodels
 KIN = rdflib.Namespace(

--- a/src/fpm/graph.py
+++ b/src/fpm/graph.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import re
 
 import numpy as np
 
@@ -14,10 +15,16 @@ from fpm.utils import build_transformation_matrix
 def build_graph_from_directory(inputs: tuple):
     # Build the graph by reading all composable models in the input folder
     g = rdflib.Graph()
+
+    def natural_sort_key(s):
+        """Split the string into a list of substrings, with numbers as numbers."""
+        return [int(text) if text.isdigit() else text.lower() for text in re.split(r'(\d+)', s)]
+
     for input_folder in inputs:
         input_models = glob.glob(os.path.join(input_folder, "*.json"))
         print("Found {} models in {}".format(len(input_models), input_folder))
         print("Adding to the graph...")
+        input_models = sorted(input_models, key=natural_sort_key)
         for file_path in input_models:
             print("\t{}".format(file_path))
             g.parse(file_path, format="json-ld")
@@ -60,7 +67,6 @@ def get_floorplan_model_name(g):
 
 
 def traverse_to_world_origin(g, frame):
-
     # Go through the geometric relation predicates
     pred_filter = traversal.filter_by_predicates([GEOM["with-respect-to"], GEOM["of"]])
     # Algorithm to traverse the graph
@@ -92,7 +98,6 @@ def traverse_to_world_origin(g, frame):
 
 
 def get_transformation_matrix_wrt_frame(g, root, target):
-
     # Configure the traversal algorithm
     filter = [GEOM["with-respect-to"], GEOM["of"]]
     pred_filter = traversal.filter_by_predicates(filter)

--- a/src/fpm/graph.py
+++ b/src/fpm/graph.py
@@ -21,13 +21,22 @@ def build_graph_from_directory(inputs: tuple):
         return [int(text) if text.isdigit() else text.lower() for text in re.split(r'(\d+)', s)]
 
     for input_folder in inputs:
-        input_models = glob.glob(os.path.join(input_folder, "*.json"))
-        print("Found {} models in {}".format(len(input_models), input_folder))
-        print("Adding to the graph...")
-        input_models = sorted(input_models, key=natural_sort_key)
-        for file_path in input_models:
-            print("\t{}".format(file_path))
-            g.parse(file_path, format="json-ld")
+        subdirectories = [d for d in glob.glob(os.path.join(input_folder, "*")) if os.path.isdir(d)]
+        for subdirectory in subdirectories:
+            input_models = glob.glob(os.path.join(subdirectory, "*.json"))
+
+            if not input_models:
+                print(f"No models found in {subdirectory}")
+                continue
+                
+            print("Found {} models in {}".format(len(input_models), input_folder))
+            print("Adding to the graph...")
+            input_models = sorted(input_models, key=natural_sort_key)
+            for file_path in input_models:
+                try:
+                    g.parse(file_path, format="json-ld")
+                except Exception as e:
+                    print(f"\tError parsing {file_path}: {e}")
 
     return g
 

--- a/src/fpm/templates/gazebo/world.sdf.jinja
+++ b/src/fpm/templates/gazebo/world.sdf.jinja
@@ -24,19 +24,34 @@
       <static>true</static>
       <pose>-0.0 0.0 0.0 0.0 0.0 0.0</pose>
     </include>
-    {% for instance in model.instances %}
+    {%- for instance in model.instances %}
+        {# Just here to add a newline before each include for readability#}
     <include>
       <name>{{instance.instance_name}}</name>
       <uri>model://{{instance.name}}</uri>
       <static>{{instance.static}}</static>
       <pose>{{instance.pose}}</pose>
-      {% for start_joint_state in instance.start_joint_states %}
+      {%- for start_joint_state in instance.start_joint_states %}
+          {%- if instance.plugin_type == 'initial' %}
         <plugin name="initial_plugin" filename="libinitial_plugin.so">
           <joint>{{start_joint_state.joint}}</joint>
           <position>{{start_joint_state.position}}</position>
         </plugin>
-      {% endfor %}
+          {%- elif instance.plugin_type == 'dynamic' %}
+        <plugin name="dynamic_joint_pluginss" filename="libdynamic_joint_plugin.so">
+          <joint>{{start_joint_state.joint}}</joint>
+          <uri>{{start_joint_state.uri}}</uri>
+        </plugin>
+          {%- elif instance.plugin_type == 'adversarial' %}
+        <plugin name="adversarial_joint_plugin" filename="libadversarial_joint_plugin.so">
+          <joint>{{start_joint_state.joint}}</joint>
+          <x>{{start_joint_state.position_before}}</x>
+          <near>{{start_joint_state.distance_to_trigger}}</near>
+          <y>{{start_joint_state.position_after}}</y>
+        </plugin>
+        {%- endif %}
+      {%- endfor %}
     </include>
-    {% endfor %}
+    {%- endfor %}
   </world>
 </sdf>

--- a/src/fpm/templates/gazebo/world.sdf.jinja
+++ b/src/fpm/templates/gazebo/world.sdf.jinja
@@ -31,23 +31,23 @@
       <uri>model://{{instance.name}}</uri>
       <static>{{instance.static}}</static>
       <pose>{{instance.pose}}</pose>
-      {%- for start_joint_state in instance.start_joint_states %}
-          {%- if instance.plugin_type == 'initial' %}
+      {%- for plugin_config in instance.plugin_configs %}
+          {%- if plugin_config.plugin_type == 'initial' %}
         <plugin name="initial_plugin" filename="libinitial_plugin.so">
-          <joint>{{start_joint_state.joint}}</joint>
-          <position>{{start_joint_state.position}}</position>
+          <joint>{{plugin_config.joint}}</joint>
+          <position>{{plugin_config.position}}</position>
         </plugin>
-          {%- elif instance.plugin_type == 'dynamic' %}
+          {%- elif plugin_config.plugin_type == 'dynamic' %}
         <plugin name="dynamic_joint_pluginss" filename="libdynamic_joint_plugin.so">
-          <joint>{{start_joint_state.joint}}</joint>
-          <uri>{{start_joint_state.uri}}</uri>
+          <joint>{{plugin_config.joint}}</joint>
+          <uri>{{plugin_config.uri}}</uri>
         </plugin>
-          {%- elif instance.plugin_type == 'adversarial' %}
+          {%- elif plugin_config.plugin_type == 'adversarial' %}
         <plugin name="adversarial_joint_plugin" filename="libadversarial_joint_plugin.so">
-          <joint>{{start_joint_state.joint}}</joint>
-          <x>{{start_joint_state.position_before}}</x>
-          <near>{{start_joint_state.distance_to_trigger}}</near>
-          <y>{{start_joint_state.position_after}}</y>
+          <joint>{{plugin_config.joint}}</joint>
+          <x>{{plugin_config.position_before}}</x>
+          <near>{{plugin_config.distance_to_trigger}}</near>
+          <y>{{plugin_config.position_after}}</y>
         </plugin>
         {%- endif %}
       {%- endfor %}

--- a/src/fpm/transformations/objects.py
+++ b/src/fpm/transformations/objects.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from rdflib import RDF
+from rdflib import RDF, URIRef
 
 from fpm.transformations.sdf import (
     get_sdf_geometry,
@@ -149,6 +149,11 @@ def get_object_instance(g, instance):
     T = get_transformation_matrix_wrt_frame(g, frame, world_frame)
     pose_coordinates = get_sdf_pose_from_transformation_matrix(T)
 
+    plugin_type = g.value(instance, OBJ["plugin"])
+    if plugin_type:
+        plugin_uri = URIRef(plugin_type)
+        plugin_type = plugin_uri.split("#")[-1]
+
     state = g.value(instance, ST["start-state"])
     start_joint_states = []
 
@@ -173,6 +178,7 @@ def get_object_instance(g, instance):
         "static": "false",
         "name": prefixed(g, of_obj)[5:],
         "instance_name": prefixed(g, instance)[5:],
+        "plugin_type": plugin_type,
         "start_joint_states": start_joint_states,
     }
 

--- a/src/fpm/transformations/objects.py
+++ b/src/fpm/transformations/objects.py
@@ -168,9 +168,9 @@ def get_object_instance(g, instance):
         #         print(f"Subject: {subj}, Predicate: {pred}, Object: {obj}")
         ########################################################
         plugin_type = str(g.value(plugin, PL["plugin-type"]))
-        state = g.value(plugin, ST["state"])
 
         if plugin_type == "initial":
+            state = g.value(plugin, ST["state"])
             start_value = get_joint_state_value(state)
 
             if not start_value:
@@ -192,17 +192,17 @@ def get_object_instance(g, instance):
             })
 
         elif plugin_type == "adversarial":
-            if ST["Transition"] in g.value(state, RDF.type):
-                start_value = get_joint_state_value(g.value(state, ST["start-state"]))
-                end_value = get_joint_state_value(g.value(state, ST["end-state"]))
-                distance = float(g.value(plugin, PL["distance"]))
-                plugins.append({
-                    "plugin_type": plugin_type,
-                    "joint": joint_name,
-                    "position_before": start_value,
-                    "distance_to_trigger": distance,
-                    "position_after": end_value
-                })
+            transition = g.value(plugin, ST["transition"])
+            start_value = get_joint_state_value(g.value(transition, ST["start-state"]))
+            end_value = get_joint_state_value(g.value(transition, ST["end-state"]))
+            distance = float(g.value(plugin, PL["distance"]))
+            plugins.append({
+                "plugin_type": plugin_type,
+                "joint": joint_name,
+                "position_before": start_value,
+                "distance_to_trigger": distance,
+                "position_after": end_value
+            })
 
     # Build a dictionary for the instance for the jinja template
     return {

--- a/src/fpm/transformations/objects.py
+++ b/src/fpm/transformations/objects.py
@@ -20,7 +20,6 @@ from fpm.graph import (
 
 def get_link_information(g, my_object, object_frame):
     for _, _, link in g.triples((my_object, OBJ["object-links"], None)):
-
         gazebo_representation = g.value(predicate=GZB["gz-link"], object=link)
 
         # Get the objects for the link geometry
@@ -149,28 +148,61 @@ def get_object_instance(g, instance):
     T = get_transformation_matrix_wrt_frame(g, frame, world_frame)
     pose_coordinates = get_sdf_pose_from_transformation_matrix(T)
 
-    plugin_type = g.value(instance, OBJ["plugin"])
-    if plugin_type:
-        plugin_uri = URIRef(plugin_type)
-        plugin_type = plugin_uri.split("#")[-1]
+    joint_name = f"{prefixed(g, instance)}-hinge-joint"
+    plugins = []
 
-    state = g.value(instance, ST["start-state"])
-    start_joint_states = []
-
-    # If the instance has a state, then include the initial state plugin
-    if state != None:
+    def get_joint_state_value(state):
+        """Helper function to get the joint state value."""
         for joint_state, _, _ in g.triples((None, ST["state"], state)):
+            if ST["JointState"] in g.value(joint_state, RDF.type):
+                return float(g.value(g.value(joint_state, ST["pose"]), QUDT["value"]))
+        return None
 
-            if not ST["JointState"] in g.value(joint_state, RDF.type):
-                continue
+    for _, _, plugin in g.triples((instance, OBJ["plugins"], None)):
+        ########################################################
+        # Use this code to query the triples in the graph by choosing subject, predicate, or object, and replacing the
+        # code plugin with the desired variable.
+        #
+        # for subj, pred, obj in g:
+        #    if subj == plugin:
+        #         print(f"Subject: {subj}, Predicate: {pred}, Object: {obj}")
+        ########################################################
+        plugin_type = str(g.value(plugin, PL["plugin-type"]))
+        state = g.value(plugin, ST["state"])
 
-            joint = g.value(joint_state, ST["joint"])
-            joint_name = prefixed(g, joint)
+        if plugin_type == "initial":
+            start_value = get_joint_state_value(state)
 
-            pose = g.value(joint_state, ST["pose"])
-            value = g.value(pose, QUDT["value"]).toPython()
+            if not start_value:
+                raise ValueError("Initial plugin must have a start value")
 
-            start_joint_states.append({"joint": joint_name, "position": value})
+            plugins.append({
+                "plugin_type": plugin_type,
+                "joint": joint_name,
+                "position": start_value
+            })
+
+
+        elif plugin_type == "dynamic":
+            uri = g.value(plugin, PL["uri"])
+            plugins.append({
+                "plugin_type": plugin_type,
+                "joint": joint_name,
+                "uri": uri
+            })
+
+        elif plugin_type == "adversarial":
+            if ST["Transition"] in g.value(state, RDF.type):
+                start_value = get_joint_state_value(g.value(state, ST["start-state"]))
+                end_value = get_joint_state_value(g.value(state, ST["end-state"]))
+                distance = float(g.value(plugin, PL["distance"]))
+                plugins.append({
+                    "plugin_type": plugin_type,
+                    "joint": joint_name,
+                    "position_before": start_value,
+                    "distance_to_trigger": distance,
+                    "position_after": end_value
+                })
 
     # Build a dictionary for the instance for the jinja template
     return {
@@ -178,8 +210,7 @@ def get_object_instance(g, instance):
         "static": "false",
         "name": prefixed(g, of_obj)[5:],
         "instance_name": prefixed(g, instance)[5:],
-        "plugin_type": plugin_type,
-        "start_joint_states": start_joint_states,
+        "plugin_configs": plugins,
     }
 
 

--- a/src/fpm/utils.py
+++ b/src/fpm/utils.py
@@ -19,7 +19,8 @@ def load_template(template_name, template_folder=None):
         loader = PackageLoader("fpm")
     else:
         loader = FileSystemLoader(template_folder)
-    env = Environment(loader=loader)
+    env = Environment(loader=loader,
+                      lstrip_blocks=True)
     return env.get_template(template_name)
 
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,0 +1,366 @@
+# Tutorial on how to Add a Plugin - Example: Adversarial Joint State Plugin
+
+This tutorial assumes that we have already written the plugin itself, and defined a set of parameters that need to be included inside our `.world` file.
+We will showcase how to add your plugin to the automatic `.world` file generation using the example of the adversarial joint state plugin. This plugin simply changes the joint state of a door when the robot enters a specified distance to the door.
+For the adversarial joint state plugin, an entry into the `.world` file looks as follows:
+
+```xml
+<plugin name="adversarial_joint_plugin" filename="libadversarial_joint_plugin.so">
+    <joint>JOINT_NAME</joint>
+    <x>JOINT_POSITION_BEFORE_TRIGGER</x>
+    <near>DISTANCE_TO_TRIGGER</near>
+    <y>JOINT_POSITION_AFTER_TRIGGER</y>
+</plugin>
+```
+
+## Identifying the Static and Dynamic Parameters
+
+When adding a new plugin, you first need to decide which parameters of the plugins we want to be more static (essentially hardcoded values or states that are used across instances of plugins, and that are not easily changed, but can contain very complex information), and which ones we want to keep more dynamic (easy to change, but only very simple values).
+
+For the adversarial joint plugin, the three parameters of importance are `x`, `near` and `y`, since the `joint_name` logically extends from the door instance we are using.
+
+To now decide which of these parameters we want to be static, and which dynamic, I found that its best to actually create an instance of a plugin state, and see how well these parameters fit into our already existing framework:
+
+### Understanding JSON-LD, and Creating a Plugin State File
+
+#### Context
+
+```json
+{
+    "@context": [
+        {
+            "pl": "https://secorolab.github.io/metamodels/plugin#",
+		    "door": "https://secorolab.github.io/models/door#"
+        },
+        "https://secorolab.github.io/metamodels/floor-plan/object.json",
+        "https://secorolab.github.io/metamodels/floor-plan/plugin.json"
+    ],
+```
+
+The context of a JSON-LD file defines the namespaces used in the file, and imports information of other JSON-LD files.
+
+In this case the code inside the curly braces defines the namespaces `https://secorolab.github.io/metamodels/plugin#`, abbreviated as `pl`, and `https://secorolab.github.io/models/door#`, abbreviated as `door`.
+
+```json
+{
+	"pl": "https://secorolab.github.io/metamodels/plugin#",
+	"door": "https://secorolab.github.io/models/door#"
+}
+```
+
+These namespaces are very important, as they connect information inside the current document, with information inside the imported documents, that use the same namespace. It is important to understand that these namespaces **do not necessarily represent actual internet URLs**. The only important thing about them is that they they **exactly** match the namespaces of the imported information.
+This information needs to be imported through files hosted either online, or locally using `python3 -m http.server 8000`. In this case, all files are hosted online
+
+```json
+"https://secorolab.github.io/metamodels/floor-plan/object.json",
+"https://secorolab.github.io/metamodels/floor-plan/plugin.json"
+```
+
+The plugin metamodel looks as follows:
+
+```json
+{
+    "@context": {
+        "pl": "https://secorolab.github.io/metamodels/plugin#",
+        "Plugin": "pl:Plugin",
+        "PluginConfiguration": "pl:PluginConfiguration",
+        "plugin-type": {
+            "@id": "pl:plugin-type",
+            "@type": "PluginConfiguration"
+        },
+        "uri": {
+            "@id": "pl:uri",
+            "@type": "PluginConfiguration"
+        }
+    }
+}
+```
+
+Here we can see the information imported into our file. It consists of, again, our namespace `"pl": "https://secorolab.github.io/metamodels/plugin#"` and then several other defined concepts contained inside the metamodel, many of which will become relevant later on.
+
+#### Graph
+
+Now that we have defined the context of our file, we will define the potential instances of our plugin that act as nodes in our graph. At first this will look as follows for all plugins you may add:
+
+```json
+"@graph": [
+        {
+            "@id": "pl:placeholder-adversarial-plugin-id",
+            "@type": "PluginConfiguration",
+            "plugin-type": "adversarial",
+        }
+    ]
+```
+
+- `"@id": "pl:placeholder-adversarial-plugin-id"`, defines the ID that we will use to assign this specific instance of the adversarial plugin to a door instance.
+- `"@type": "PluginConfiguration"` may be used at some point in our code to ensure that the information entered into the graph is the correct type, since JSON-LD does not have any form of type checking.
+- `"plugin-type": "adversarial"` will be used later in our python code to identify which plugin is currently being parsed.
+
+#### Adding Our Parameters
+
+To reiterate, we identified three different important parameters for our plugin:
+
+- `x`: the joint position before the trigger
+- `near`: the distance at which the plugin triggers in meter
+- `y`: the joint position after the trigger
+
+If we look at existing models and metamodels in our repositories, we will notice that the we already have several different door states defined here, as well as, more importantly, *transitions*, from one state to another. Both the `state` of the doors, and the `transition` between these states, are types defined inside the state metamodel, which can be imported using `"https://secorolab.github.io/metamodels/floor-plan/state.json"`, and the actual definition of the state or transition is defined inside the `object-door-states.json` (update as soon as we decided where object-door-states should be located). Since we literally need a transition between `x` and `y`, it makes sense to add another field `transition` to our instance, and since we have six different transitions defined inside `object-door-states.json`, we will now define six different instances of our adversarial joint plugin, each with a unique `id`:
+
+```json
+"@graph": [
+        {
+            "@id": "pl:door-opened-to-closed-adversarial-plugin",
+            "@type": "PluginConfiguration",
+            "plugin-type": "adversarial",
+            "transition": "door:transition-from-door-fully-opened-to-door-fully-closed"
+        },
+        {
+            "@id": "pl:door-closed-to-opened-adversarial-plugin",
+            "@type": "PluginConfiguration",
+            "plugin-type": "adversarial",
+            "transition": "door:transition-from-door-fully-closed-to-door-fully-opened"
+        },
+        {
+            "@id": "pl:door-closed-to-partially-adversarial-plugin",
+            "@type": "PluginConfiguration",
+            "plugin-type": "adversarial",
+            "transition": "door:transition-from-door-fully-closed-to-door-partially-opened"
+        },
+        {
+            "@id": "pl:door-partially-to-closed-adversarial-plugin",
+            "@type": "PluginConfiguration",
+            "plugin-type": "adversarial",
+            "transition": "door:transition-from-door-partially-opened-to-door-fully-closed"
+        },
+        {
+            "@id": "pl:door-partially-to-opened-adversarial-plugin",
+            "@type": "PluginConfiguration",
+            "plugin-type": "adversarial",
+            "transition": "door:transition-from-door-partially-opened-to-door-fully-opened"
+        },
+        {
+            "@id": "pl:door-opened-to-partially-adversarial-plugin",
+            "@type": "PluginConfiguration",
+            "plugin-type": "adversarial",
+            "transition": "door:transition-from-door-fully-opened-to-door-partially-opened"
+        }
+    ]
+```
+
+From that `transition`, we will later be able to extract the positions for `x` and `y`.
+Now we need to define `near`. Now we have two options for what to do. Either we create another field `near` (or `distance`, as it is more descriptive) or we define the parameter when we add the plugin to our door instance.
+Since we preferably want all permutations of combinations, as a individual instance, just having z=3 different values, for example 1m, 0.5m, 0,25m, would mean that we end up with 6\*z=18 different instances, which all need to have unique names, which will consequently either get increasingly long, or increasingly less descriptive.
+A better way to do it instead, is to define the `distance` parameter inside our door instance instead.
+
+## Adding the Plugins to a Door Instance
+
+After locating the file of door-instance-1 in our model folder, we need to find an entry already adding an instance of the `initial-state-plugin` (since every door-instance must have an instance of the `initial-state-plugin`):
+
+```json
+{
+	"@id": "door:door-instance-1",
+	"@type": "ObjectInstance",
+	"frame": "geom:frame-location-door-1",
+	"of-object": "door:door",
+	"world": "floorplan:frontiers_brsu_building_c",
+	"plugins": [
+		{
+			"@id": "pl:door-partially-opened-init-plugin"
+		}
+	]
+}
+```
+
+Now to add a instance of our new plugin (for example `pl:door-opened-to-closed-adversarial-plugin`) to this door instance, and also set the `distance` parameter, we first need to add it to our `plugin.json` metamodel, which should now look as follows:
+
+```json
+{
+    "@context": {
+        "pl": "https://secorolab.github.io/metamodels/plugin#",
+        "Plugin": "pl:Plugin",
+        "PluginConfiguration": "pl:PluginConfiguration",
+        "plugin-type": {
+            "@id": "pl:plugin-type",
+            "@type": "PluginConfiguration"
+        },
+        "uri": {
+            "@id": "pl:uri",
+            "@type": "PluginConfiguration"
+        },
+        "distance": {
+            "@id": "pl:distance",
+            "@type": "PluginConfiguration"
+        },
+    }
+}
+```
+
+Then we need to edit the code of our door instance code as follows:
+
+```json
+{
+	"@id": "door:door-instance-1",
+	"@type": "ObjectInstance",
+	"frame": "geom:frame-location-door-1",
+	"of-object": "door:door",
+	"world": "floorplan:frontiers_brsu_building_c",
+	"plugins": [
+		{
+			"@id": "pl:door-partially-opened-init-plugin"
+		},
+		{
+			"@id": "pl:door-opened-to-closed-adversarial-plugin",
+			"distance": "0.9"
+		}
+	]
+}
+```
+
+## Parsing the Plugin inside the Scenery Builder
+
+Inside the `scenery_builder` repository, inside the method `get_object_instance` of the file `src/fpm/transformations/objects.py`, is where the parsing of the plugins happens. In line 172, we find the following `If` statements:
+
+```Python
+if plugin_type == "initial":  
+    state = g.value(plugin, ST["state"])  
+    start_value = get_joint_state_value(state)  
+  
+    if not start_value:  
+        raise ValueError("Initial plugin must have a start value")  
+  
+    plugins.append({  
+        "plugin_type": plugin_type,  
+        "joint": joint_name,  
+        "position": start_value  
+    })  
+  
+  
+elif plugin_type == "dynamic":  
+    uri = g.value(plugin, PL["uri"])  
+    plugins.append({  
+        "plugin_type": plugin_type,  
+        "joint": joint_name,  
+        "uri": uri  
+    })  
+```
+
+Here we now add another case for `plugin_type == "adversarial"`. First thing we will do is extract the value of the `transition` field, and from here, extract the `start_value`, which will be our `x`, and the `end_value`, which will be our `y`. Afterwards we will extract the value of the `distance` field which will be our `near`.
+Lastly we will append this information, as well as the `joint` and the `plugin_type`, which will have been extracted earlier, to our `plugins` list.
+
+```Python
+elif plugin_type == "adversarial":  
+    transition = g.value(plugin, ST["transition"])  
+    start_value = get_joint_state_value(g.value(transition, ST["start-state"]))  
+    end_value = get_joint_state_value(g.value(transition, ST["end-state"]))  
+    distance = float(g.value(plugin, PL["distance"]))  
+    plugins.append({  
+        "plugin_type": plugin_type,  
+        "joint": joint_name,  
+        "position_before": start_value,  
+        "distance_to_trigger": distance,  
+        "position_after": end_value  
+    })
+```
+
+One last tip:
+Dealing with `g.value()` calls can be quite tricky. What helped me a lot is using the following loop, to query the current graph and find out which parameters I need to query, or spot instances where I maybe made a mistake inside the JSON-LD files:
+
+```Python
+for subj, pred, obj in g:
+	if subj == plugin:  
+	    print(f"Subject: {subj}, Predicate: {pred}, Object: {obj}")
+```
+
+In this loop, you can swap out the subject, predicate and object depending on your query, and swap our plugin with the value that subject/predicate/object you are interested in.
+
+## Adding the New Plugin to the Jinja Template
+
+The `world.sdf.jinja` file can be found inside the `scenery_builder`, at `src/fpm/templates/gazebo/world.sdf.jinja`. In Line 34 you should find the following code block:
+
+```xml
+{%- for plugin_config in instance.plugin_configs %}  
+    {%- if plugin_config.plugin_type == 'initial' %}  
+	<plugin name="initial_plugin" filename="libinitial_plugin.so">  
+	    <joint>{{plugin_config.joint}}</joint>  
+	    <position>{{plugin_config.position}}</position>  
+	</plugin>    
+	{%- elif plugin_config.plugin_type == 'dynamic' %}  
+	<plugin name="dynamic_joint_pluginss" filename="libdynamic_joint_plugin.so">  
+	    <joint>{{plugin_config.joint}}</joint>  
+	    <uri>{{plugin_config.uri}}</uri>  
+	</plugin>    
+	{%- endif %}  
+{%- endfor %}
+```
+
+To now add our new plugin, we need to add another `elif` statement, and then extract the values using the keywords we have previously defined inside the dictionary we appended to the `plugin` list:
+
+```xml
+{%- elif plugin_config.plugin_type == 'adversarial' %}  
+<plugin name="adversarial_joint_plugin" filename="libadversarial_joint_plugin.so">  
+	<joint>{{plugin_config.joint}}</joint>  
+	<x>{{plugin_config.position_before}}</x>  
+	<near>{{plugin_config.distance_to_trigger}}</near>  
+	<y>{{plugin_config.position_after}}</y>  
+</plugin>
+```
+
+## Design Decisions and Examples
+
+Currently, continuing with the same design choices made for the door states, our plugin states JSON-LD files multiple unique instances of the same plugin, with each instance representing a unique plugin configuration. Each unique configuration should be easily identifiable by its ID, to make it easy to use. For example:
+
+- `"pl:door-partially-to-closed-adversarial-plugin"` is the adversarial door plugin with a configuration that has a partially-opened door state (0.7) as the start state, and the closed door state (0.0) as the end state.
+- `"pl:door-opened-to-closed-adversarial-plugin"` is the adversarial door plugin with a configuration that has a fully-opened door state (1.6) as the start state, and the closed door state (0.0) as the end state.
+- `"pl:door-opened-to-partially-adversarial-plugin"` is the adversarial door plugin with a configuration that has a fully-opened door state (1.6) as the start state, and the partially-opened door state (0.7) as the end state.
+
+While we may use the same plugin ID for multiple door instances, each instance is assigned its own plugin using the jinja template. This is also evidenced by the fact, that some plugins, like the adversarial door plugin, have dynamic parameters like the `distance` parameter, that may be totally unique for each door instance.
+Adding the following to door-instance-1:
+
+```xml
+{
+"@id": "pl:door-opened-to-closed-adversarial-plugin",
+"distance": "0.9"
+},
+```
+
+Will result in this plugin being generated:
+
+```xml
+<plugin name="adversarial_joint_plugin" filename="libadversarial_joint_plugin.so">
+  <joint>door:door-instance-1-hinge-joint</joint>
+  <x>1.6</x>
+  <near>0.9</near>
+  <y>0.0</y>
+</plugin>
+```
+
+And adding the following to door-instance-2, using a different value for “distance”, but otherwise the same plugin configuration:
+
+```xml
+{
+"@id": "pl:door-opened-to-closed-adversarial-plugin",
+"distance": "0.3"
+},
+```
+
+Will result in this plugin being generated:
+
+```xml
+<plugin name="adversarial_joint_plugin" filename="libadversarial_joint_plugin.so">
+  <joint>door:door-instance-2-hinge-joint</joint>
+  <x>1.6</x>
+  <near>0.3</near>
+  <y>0.0</y>
+</plugin>
+```
+
+Using this method, we make sure to have as little duplicated code as possible, since we clearly define the most common plugin states, while still maintaining some flexibility by being able to assign dynamic parameters like the `distance` parameter, and while still making sure the plugins are easy to use.
+This still comes with some tradeoffs. We need to carefully choose the static parameters, since too many too many instances of the static parameters will result in a lot of unique plugin config permutations. For example we have three predefined door states, (opened, partially, closed), and this already resulted in 6 unique transitions.
+
+If it turns out that we need unique IDs for each plugin, I would recommend generating the ID inside the python code and then inserting it into the jinja template, similar to how i currently generate the joint-name of each instance:
+
+```Python
+joint_name = f"{prefixed(g, instance)}-hinge-joint"
+```
+
+Using this, the joint-name of door-instance-1 would be `door:door-instance-1-hinge-joint`.


### PR DESCRIPTION
# Plugins

## Mandatory Plugins

### Initial Plugin

Every door should always have an instance of the initial state plugin. “@id” will usually be chosen from a predefined set of plugin configurations.
Currently, there exist three different configurations:

- full-opened
- partially-opened
- fully-closed

If these are not suitable for your specific case, you may also create new plugin configuration. We will get to how to add your own plugins and configurations a bit later.

The following is an example illustrates how to add a initial plugin with the configuration “partially-opened”, to the graph for the door-instance-1:

```json
{  
	"@id": "door:door-instance-1",  
	"@type": "ObjectInstance",  
	"frame": "geom:frame-location-door-1",  
	"of-object": "door:door",  
	"world": "floorplan:frontiers_brsu_building_c",  
	"plugins": [  
		{  
			"@id": "pl:door-partially-opened-init-plugin"  
		}
	]  
} 
```

## Optional Plugins

### Dynamic Plugin

The dynamic plugin currently only has one ID in use. Since JSON-LD does allow for dynamic variable passing, and the URI will be a link to a file containing the keyframes at which the door should open/close, it is not predefined in some config, but needs to be set manually as shown in the example:

```json
{  
    "@id": "pl:door-dynamic-plugin",  
    "uri": "testURI"  
}
```

### Adversarial Plugin

The adversarial plugin utilizes transitions from a start-state, to a end-state. Currently, there exist three different states:

- opened
- closed
- partially

each combination of these states has its own transition.
In addition to that, we also need to set a “distance” parameter here, which is the distance at which the distance at which the robot will trigger the transition from start-state to the end-state

So in general an adversarial plugin will always look as follows:

```json 
{  
    "@id": "pl:door-{start-state}-to-{end-state}-adversarial-plugin",  
    "distance": distance_to_trigger_transition
}
```

This is a specific example for start-state “opened”, and end-state “closed”, which triggers if the robots distance to the door is 90cm:

```json 
{  
    "@id": "pl:door-opened-to-closed-adversarial-plugin",  
    "distance": "0.9"  
}
```

## Adding New Plugins and Configurations

If you want to create a plugin of a new type, you must first create a new file `new-plugin-states.sjon` using the following template:

```json
{
    "@context": [
        {
            "pl": "https://secorolab.github.io/metamodels/plugin#",
		    "door": "https://secorolab.github.io/models/door#"
        },
        "https://comp-rob2b.github.io/metamodels/geometry/spatial-relations.json",
        "https://comp-rob2b.github.io/metamodels/geometry/structural-entities.json",
        "https://comp-rob2b.github.io/metamodels/geometry/coordinates.json",
        "https://comp-rob2b.github.io/metamodels/kinematic-chain/structural-entities.json",
        "https://secorolab.github.io/metamodels/floor-plan/object.json",
        "https://secorolab.github.io/metamodels/geometry/polytope.json",
        "https://secorolab.github.io/metamodels/floor-plan/state.json",
        "http://localhost:8000/floor-plan/plugin.json",
        "https://comp-rob2b.github.io/metamodels/qudt.json",
        "https://secorolab.github.io/metamodels/geometry/coordinate-extension.json"
    ],
    "@graph": [
        {
            "@id": "pl:door-state_of_plugin-new_type-plugin",
            "@type": "PluginConfiguration",
            "plugin-type": "new_type",
            "state": "state_of_plugin"
        }
    ]
}   
```

If your plugin benefits from having a dynamic parameter similar to the `uri` parameter from the dynamic plugin, or the `distance` parameter from the adversarial plugin, then you must add a new parameter to `metamodels/floor-plan/plugin.json`, using the following template:

```json
"new_parameter": {
            "@id": "pl:new_parameter",
            "@type": "PluginConfiguration"
        }
```

### Adding the New Plugin to the Template

First we need to access all parameters needed for our plugin. This is done inside `scenery_builder/src/fpm/transformations/objects.py`, inside the `get_object_instance` function.
Locate the `if-elif` blocks at Line ~180, and append a new `elif`. Here is an example for the adversarial joint plugin:

```Python
elif plugin_type == "adversarial":  
    if ST["Transition"] in g.value(state, RDF.type):  
        start_value = get_joint_state_value(g.value(state, ST["start-state"]))  
        end_value = get_joint_state_value(g.value(state, ST["end-state"]))  
        distance = float(g.value(plugin, PL["distance"]))  
        plugins.append({  
            "plugin_type": plugin_type,  
            "joint": joint_name,  
            "position_before": start_value,  
            "distance_to_trigger": distance,  
            "position_after": end_value  
        })
```

In this case, we first make sure that the state is of type `ST["Transition"]`, since we rely on its `start-state` and `end-state` is. Also notice that, in order to retrieve the `distance` parameter, we need to access `plugin`, not `state`.
Inside the appended dictionary, make sure to keep the “plugin_type” keyword, but other than that you may use any number of unique keywords you need for your plugin.

Afterwards, inside the file `scenery_builder/src/fpm/templates/gazebo/world.sdf.jinja`, you will find a `for-loop` used to iterate through all plugins of the current instance around Line 34. Append a new `elif` statement at the end. Here is an example for the adversarial joint plugin:

```
{%- elif plugin_config.plugin_type == 'adversarial' %}  
<plugin name="adversarial_joint_plugin" filename="libadversarial_joint_plugin.so">  
  <joint>{{plugin_config.joint}}</joint>  
  <x>{{plugin_config.position_before}}</x>  
  <near>{{plugin_config.distance_to_trigger}}</near>  
  <y>{{plugin_config.position_after}}</y>  
</plugin>
```
