### PR TITLE
Add generation of occupancy grid based on configurable laser height

### DIFF
--- a/src/fpm/generators/occ_grid.py
+++ b/src/fpm/generators/occ_grid.py
@@ -200,6 +200,7 @@ def save_map_metadata(output_path, map_name, center, **custom_args):
     resolution = custom_args.get("map_resolution", 0.05)
     occupied_thresh = custom_args.get("map_occupied_threshold", 0.65)
     free_thresh = custom_args.get("map_free_threshold", 0.196)
+    laser_height = custom_args.get("map_laser_height", 0.7)
     map_metadata = {
         "resolution": resolution,
         "origin": center,
@@ -207,6 +208,7 @@ def save_map_metadata(output_path, map_name, center, **custom_args):
         "free_thresh": free_thresh,
         "negate": negate,
         "image": "{}.pgm".format(map_name),
+        "laser_height": laser_height,
     }
 
     save_file(output_path, file_name, map_metadata)

--- a/src/fpm/generators/occ_grid.py
+++ b/src/fpm/generators/occ_grid.py
@@ -23,7 +23,6 @@ def generate_occ_grid(g, output_path, **custom_args):
     unknown = custom_args.get("map_unknown_value", 200)
     occupied = custom_args.get("map_occupied_value", 0)
     free = custom_args.get("map_free_value", 255)
-    laser_height = custom_args.get("map_laser_height", 0.7)
     border = custom_args.get("map_border", 50)
 
     if "{{model_name}}" in output_path:
@@ -109,10 +108,17 @@ def generate_occ_grid(g, output_path, **custom_args):
 def draw_floorplan_obstacle(g, element, draw, west, south, fill, coords_map, **kwargs):
     column_points = get_wall_points(g, element)
     c_points = list()
+
+    laser_height = kwargs.get("map_laser_height", 0.7)
     for s in column_points:
+        height = s.get("height")
+        if laser_height > height:
+            # Don't process elements that are below the laser height
+            continue
+
         c_coords = list()
         for p in s.get("points"):
-            x, y, _ = get_waypoint_coord(g, p, coords_map)
+            x, y, z = get_waypoint_coord(g, p, coords_map)
             c_coords.append([x, y, 0, 1])
 
         c_coords = np.array(c_coords)

--- a/src/fpm/generators/occ_grid.py
+++ b/src/fpm/generators/occ_grid.py
@@ -137,9 +137,12 @@ def draw_floorplan_obstacle(g, element, draw, west, south, fill, coords_map, **k
 def draw_floorplan_opening(g, element, draw, west, south, fill, coords_map, **kwargs):
     opening_points = get_opening_points(g, element)
     resolution = kwargs.get("resolution", 0.05)
+    laser_height = kwargs.get("map_laser_height", 0.7)
 
     all_points = list()
     for opening in opening_points:
+        opening_height_max = 0.0
+        opening_height_min = float("inf")
         for face in opening:
             y_vals = [p.get("y") for p in face]
             if np.all(np.array(y_vals) == y_vals[0]):
@@ -150,10 +153,15 @@ def draw_floorplan_opening(g, element, draw, west, south, fill, coords_map, **kw
                     p["y"] = p["y"] - resolution
                 else:
                     p["y"] = p["y"] + resolution
-                x, y, _ = get_waypoint_coord(g, p, coords_map)
+                x, y, z = get_waypoint_coord(g, p, coords_map)
                 f_coords.append([x, y, 0, 1])
-            f_coords = np.array(f_coords)
-            all_points.append(f_coords)
+                if z > opening_height_max:
+                    opening_height_max = z
+                elif z < opening_height_min:
+                    opening_height_min = z
+            if opening_height_min <= laser_height <= opening_height_max:
+                f_coords = np.array(f_coords)
+                all_points.append(f_coords)
 
     draw_floorplan_element(all_points, draw, fill, west=west, south=south, **kwargs)
 

--- a/src/fpm/graph.py
+++ b/src/fpm/graph.py
@@ -190,6 +190,7 @@ def get_wall_points(g, element="Wall"):
     wall_points = list()
     for wall, _, _ in g.triples((None, RDF.type, FP[element])):
         wall_points_json = get_point_positions_in_space(g, wall)
+        wall_points_json["height"] = g.value(wall, FP["height"]).toPython()
         wall_points.append(wall_points_json)
 
     return wall_points


### PR DESCRIPTION
Closes #16 

This PR also adds the `laser_height` to the map metadata (stored in the `.yaml` file)