### PR TITLE
Fix ROS 2 (jazzy) gazebo launch files

### DIFF
--- a/src/fpm/templates/gazebo/world.sdf.jinja
+++ b/src/fpm/templates/gazebo/world.sdf.jinja
@@ -2,28 +2,46 @@
 <sdf version="1.6">
   <world name="{{model.name}}">
     <gravity>0 0 -9.8</gravity>
+
     <physics default="0" name="default_physics" type="ode">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
       <real_time_update_rate>1000</real_time_update_rate>
     </physics>
+
     <scene>
       <ambient>0.6 0.6 0.6 1</ambient>
       <background>0.4 0.4 0.4 1</background>
       <shadows>false</shadows>
     </scene>
+
     <include>
-      <uri>model://sun</uri>
+        <uri>
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Sun
+        </uri>
     </include>
-    <include>
-      <uri>model://ground_plane</uri>
+
+    <model name='ground_plane'>
+      <static>true</static>
+      <link name='link'>
+        <collision name='collision'>
+          <geometry>
+            <plane>
+              <normal>0.0 0.0 1</normal>
+              <size>1 1</size>
+            </plane>
+          </geometry>
+        </collision>
+      </link>
       <pose>0 0 0 0 0 0</pose>
-    </include>
+    </model>
+
     <include>
       <uri>model://{{model.name}}</uri>
       <static>true</static>
       <pose>-0.0 0.0 0.0 0.0 0.0 0.0</pose>
     </include>
+
     {% for instance in model.instances %}
     <include>
       <name>{{instance.instance_name}}</name>

--- a/src/fpm/templates/ros/world.ros2.launch.jinja
+++ b/src/fpm/templates/ros/world.ros2.launch.jinja
@@ -2,26 +2,21 @@
 
 <!-- ROS2 Launch File - Supports ROS2 Jazzy -->
 <launch>
-    
 
-    <!-- GAZEBO SETUP ARGUMENTS -->
-    <arg name="use_sim_time" default="true"/>
-    <arg name="gazebo_gui" default="false"/>
-    <arg name="headless" default="true"/>
-    <arg name="debug" default="false"/>
-    <arg name="paused" default="false"/>
-    <arg name="world_name" default="worlds/{{model_name}}.sdf"/>
+  <set_env name="GZ_SIM_RESOURCE_PATH" value="$(find-pkg-prefix floorplan_models)/models:$(find-pkg-prefix floorplan_models)/worlds:$(env GZ_SIM_RESOURCE_PATH)"/>
 
-    <set_env name="GAZEBO_MODEL_PATH" value="$(find-pkg-prefix floorplan_models)/models:$(find-pkg-prefix floorplan_models)/worlds:$(env GAZEBO_MODEL_PATH)"/>
+  <arg name="container_name" default="ros_gz_container" />
+  <arg name="create_own_container" default="False" />
+  <arg name="use_composition" default="False" />
+  <arg name="world_sdf_file" default="{{model_name}}.sdf" />
+  <arg name="world_sdf_string" default="" />
+  <gz_server
+    world_sdf_file="$(var world_sdf_file)"
+    world_sdf_string="$(var world_sdf_string)"
+    container_name="$(var container_name)"
+    create_own_container="$(var create_own_container)"
+    use_composition="$(var use_composition)">
+  </gz_server>
 
-    <!-- launch gazebo with empty world -->
-    <include file="$(find floorplan_models)/launch/gazebo_world.launch">
-        <let name="world_name" value="$(var world_name)"/>
-        <let name="paused" value="$(var paused)"/>
-        <let name="use_sim_time" value="$(var use_sim_time)"/>
-        <let name="gui" value="$(var gazebo_gui)"/>
-        <let name="headless" value="$(var headless)"/>
-        <let name="debug" value="$(var debug)"/>
-    </include>
 
 </launch>


### PR DESCRIPTION
- Fixed the launch file template for ROS2 so that it launches only the gz_server on Gazebo Ionic
- Made the world.sdf template self-contained (includes/fixes the URI to ground plane and sun models)