### PR TITLE
Use new STL export for blender 4.1+

### DIFF
--- a/src/fpm/utils.py
+++ b/src/fpm/utils.py
@@ -37,7 +37,7 @@ def save_file(output_path, file_name, contents):
     elif ext in [".pgm", ".jpg"]:
         contents.save(output_file, quality=95)
     elif ext in [".stl"]:
-        bpy.ops.export_mesh.stl(filepath=output_file)
+        bpy.ops.wm.stl_export(filepath=output_file)
     elif ext in [".dae"]:
         bpy.ops.wm.collada_export(filepath=output_file)
     else:


### PR DESCRIPTION
Deprecation notice: https://developer.blender.org/docs/release_notes/4.1/pipeline_assets_io/#stl