### PR TITLE
Add gltf export

### DIFF
--- a/src/fpm/generators/mesh.py
+++ b/src/fpm/generators/mesh.py
@@ -62,3 +62,4 @@ def subtract_opening(openings):
 def get_3d_mesh(g, base_path, **kwargs):
     output_path = get_output_path(base_path, "3d-mesh")
     generate_3d_mesh(g, output_path, **kwargs)
+    generate_3d_mesh(g, output_path, format="gltf")

--- a/src/fpm/utils.py
+++ b/src/fpm/utils.py
@@ -40,6 +40,8 @@ def save_file(output_path, file_name, contents):
         bpy.ops.wm.stl_export(filepath=output_file)
     elif ext in [".dae"]:
         bpy.ops.wm.collada_export(filepath=output_file)
+    elif ext == ".gltf":
+        bpy.ops.export_scene.gltf(filepath=output_file)
     else:
         with open(output_file, "w") as f:
             f.write(contents)


### PR DESCRIPTION
Add export of the 3D mesh using the [gltf](https://docs.blender.org/api/current/bpy.ops.export_scene.html#bpy.ops.export_scene.gltf) scene export API. 