### PR TITLE
Split CLI generate command into individual commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR /usr/src/app/
 
 ENTRYPOINT ["blender", "-b", "--python", "modules/fpm/cli.py", "--", "generate"]
 
-CMD ["-i", "/usr/src/app/models/", "--output-path", "/usr/src/app/output/"]
+CMD ["-i", "/usr/src/app/models/", "--output-path", "/usr/src/app/output/", "mesh", "tasks", "gazebo", "occ-grid", "polyline", "door-keyframes"]

--- a/config/config.toml
+++ b/config/config.toml
@@ -9,23 +9,24 @@
 # No options for now
 
 [generate.tasks]
-waypoint_dist_to_corner = 0.7
+dist_to_corner = 0.7
 
 [generate.gazebo]
 ros_version = "ros1"
 ros_pkg = "floorplan_models"
 
 [generate.occ_grid]
-map_laser_height = 0.7
-map_border = 50
+border = 50
+# generation metadata
+laser_height = 0.7
 # map_server required metadata
-map_resolution = 0.05
-map_occupied_threshold = 0.65
-map_free_threshold = 0.196
-map_negate = 0
-map_unknown_value = 200
-map_occupied_value = 0
-map_free_value = 255
+resolution = 0.05
+occupied_threshold = 0.65
+free_threshold = 0.196
+negate = 0
+unknown_value = 200
+occupied_value = 0
+free_value = 255
 
 
 #[generate.polyline]
@@ -33,8 +34,8 @@ map_free_value = 255
 
 
 [generate.door_keyframes]
-keyframe_start = 0
-keyframe_end = 180
-keyframe_start_state = 0.0
-keyframe_sampling_interval = 30
-keyframe_state_change_probability = 0.5
+start_frame = 0
+end_frame = 180
+start_state = 0.0
+sampling_interval = 30
+state_change_probability = 0.5

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,0 +1,40 @@
+# Parametrize the transformations
+
+#[generate]
+#inputs =
+#outputs =
+#templates =
+
+#[generate.mesh]
+# No options for now
+
+[generate.tasks]
+waypoint_dist_to_corner = 0.7
+
+[generate.gazebo]
+ros_version = "ros1"
+ros_pkg = "floorplan_models"
+
+[generate.occ_grid]
+map_laser_height = 0.7
+map_border = 50
+# map_server required metadata
+map_resolution = 0.05
+map_occupied_threshold = 0.65
+map_free_threshold = 0.196
+map_negate = 0
+map_unknown_value = 200
+map_occupied_value = 0
+map_free_value = 255
+
+
+#[generate.polyline]
+# No options for now
+
+
+[generate.door_keyframes]
+keyframe_start = 0
+keyframe_end = 180
+keyframe_start_state = 0.0
+keyframe_sampling_interval = 30
+keyframe_state_change_probability = 0.5

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,10 +38,10 @@ pip install -e .
 This module adds `floorplan` as a command line interface. You can use the `generate` command as shown below:
 
 ```shell
-floorplan generate <path to config file> -i <path to input folder>
+floorplan generate -i <path to input folder>
 ```
 
-Where the input folder must contain:
+Where the input folder(s) must contain:
 - the composable models generated from the [FloorPlan DSL](https://github.com/secorolab/FloorPlan-DSL)
     - `coordinate.json`
     - `floorplan.json`
@@ -70,10 +70,16 @@ The command above currently generates the following artefacts:
 
 ### Docker
 
-To use the scenery_builder via Docker, simply mount the input and output paths as volumes and pass any arguments to the container:
+To use the scenery_builder via Docker, simply mount the input and output paths as volumes and run the container. This will run the `floorplan generate` command with the default values defined in the entrypoint.
 
 ```bash
-docker run -v <local input path>:/usr/src/app/models -v <local output path>:/usr/src/app/output  -it scenery_builder:latest <optional arguments>
+docker run -v <local input path>:/usr/src/app/models -v <local output path>:/usr/src/app/output scenery_builder:latest
+```
+
+If you want to change the path of the volumes inside the Docker container (i.e., `/usr/src/app/models` or `/usr/src/app/output`) or want to customize the arguments, use the following:
+
+```bash
+docker run -v <local input path>:/usr/src/app/models -v <local output path>:/usr/src/app/output scenery_builder:latest -i /usr/src/app/models -o /usr/src/app/output <optional arguments>
 ```
 
 ## Example
@@ -84,7 +90,7 @@ An example model for a building is available [here](https://github.com/secorolab
 
 
 ```sh
-floorplan generate -i hospital/json-ld --output-path hospital/gen
+floorplan generate -i hospital/json-ld -o hospital/gen
 ```
 
 That should generate the following files:
@@ -119,7 +125,7 @@ That should generate the following files:
 ## Task generator
 
 It uses the FloorPlan corners to generate a task specification to visit all corners in a space.
-The option `--waypoint-dist-to-corner` is a float value representing the distance between the corner of a space and its center.
+The option `--dist-to-corner` is a float value representing the distance between the corner of a space and its center.
 
 ## Object placing
 

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -15,7 +15,8 @@ def floorplan():
     pass
 
 
-@floorplan.command()
+@floorplan.group()
+@click.pass_context
 @click.option(
     "--inputs",
     "--input-path",
@@ -39,6 +40,45 @@ def floorplan():
     default=os.path.join("."),
     help="Path with Jinja templates",
 )
+def generate(ctx, inputs, output_path, **kwargs):
+    print(kwargs)
+
+    g = build_graph_from_directory(inputs)
+    model_name = get_floorplan_model_name(g)
+
+    ctx.ensure_object(dict)
+    ctx.obj[model_name] = model_name
+    ctx.obj["graph"] = g
+
+    print("End of generate command")
+
+
+@generate.command()
+@click.pass_context
+def mesh(ctx, **kwargs):
+    print("test")
+    print(ctx.obj)
+    print(kwargs)
+    g = ctx.obj["graph"]
+    # get_3d_mesh(g, output_path, **kwargs)
+
+
+@generate.command()
+@click.pass_context
+@click.option(
+    "--waypoint-dist-to-corner",
+    type=click.FLOAT,
+    default=0.7,
+    show_default=True,
+    help="Distance between generated waypoints and a space's corner",
+)
+def tasks(ctx, **kwargs):
+    g = ctx.obj["graph"]
+    # get_tasks(g, output_path, **kwargs)
+
+
+@generate.command()
+@click.pass_context
 @click.option(
     "--ros-version",
     type=click.STRING,
@@ -53,13 +93,14 @@ def floorplan():
     show_default=True,
     help="Name of the ROS package where gazebo models",
 )
-@click.option(
-    "--waypoint-dist-to-corner",
-    type=click.FLOAT,
-    default=0.7,
-    show_default=True,
-    help="Tasks: Distance between generated waypoints and a space's corner",
-)
+def gazebo(ctx, **kwargs):
+    g = ctx.obj["graph"]
+    # door_object_models(g, output_path, **kwargs)
+    # gazebo_world(g, model_name, output_path, **kwargs)
+
+
+@generate.command()
+@click.pass_context
 @click.option(
     "--map-laser-height",
     type=click.FLOAT,
@@ -123,6 +164,20 @@ def floorplan():
     show_default=True,
     help="Map: Value for cells to be considered free in the occupancy map",
 )
+def occ_grid(ctx, **kwargs):
+    g = ctx.obj["graph"]
+    # get_occ_grid(g, output_path, **kwargs)
+
+
+@generate.command()
+@click.pass_context
+def polyline(ctx, **kwargs):
+    g = ctx.obj["graph"]
+    # get_polyline_floorplan(g, output_path, **kwargs)
+
+
+@generate.command()
+@click.pass_context
 @click.option(
     "--keyframe-start",
     type=click.INT,
@@ -158,22 +213,9 @@ def floorplan():
     show_default=True,
     help="Probability of a door changing states at the next interval",
 )
-def generate(inputs, output_path, **kwargs):
-    print(kwargs)
-
-    g = build_graph_from_directory(inputs)
-    model_name = get_floorplan_model_name(g)
-
-    get_tasks(g, output_path, **kwargs)
-
-    door_object_models(g, output_path, **kwargs)
-    gazebo_world(g, model_name, output_path, **kwargs)
-
-    get_occ_grid(g, output_path, **kwargs)
-    get_3d_mesh(g, output_path, **kwargs)
-
-    get_polyline_floorplan(g, output_path, **kwargs)
-    get_keyframes(output_path, **kwargs)
+def door_keyframes(ctx, **kwargs):
+    g = ctx.obj["graph"]
+    # get_keyframes(output_path, **kwargs)
 
 
 if __name__ == "__main__":

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -3,7 +3,7 @@ import click
 
 from fpm.graph import build_graph_from_directory, get_floorplan_model_name
 from fpm.generators.gazebo import gazebo_world, door_object_models
-from fpm.generators.tasks import get_tasks
+from fpm.generators.tasks import get_disinfection_tasks
 from fpm.generators.occ_grid import get_occ_grid
 from fpm.generators.mesh import get_3d_mesh
 from fpm.generators.polyline import get_polyline_floorplan
@@ -94,7 +94,7 @@ def mesh(ctx, **kwargs):
 )
 def tasks(ctx, **kwargs):
     """Generate disinfection tasks for each room in the floorplan"""
-    get_tasks(**ctx.obj, **ctx.parent.params, **kwargs)
+    get_disinfection_tasks(**ctx.obj, **ctx.parent.params, **kwargs)
 
 
 @generate.command()

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -101,8 +101,8 @@ def tasks(ctx, **kwargs):
 @click.pass_context
 @click.option(
     "--ros-version",
-    type=click.STRING,
-    default="ros2",
+    type=click.Choice(["ROS2", "ROS1"], case_sensitive=False),
+    default="ROS2",
     show_default=True,
     help="ROS version for launch files",
 )

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -7,6 +7,7 @@ from fpm.generators.tasks import tasks
 from fpm.generators.occ_grid import get_occ_grid
 from fpm.generators.mesh import get_3d_mesh
 from fpm.generators.polyline import get_polyline_floorplan
+from fpm.generators.door_keyframes import get_keyframes
 
 
 @click.group()
@@ -122,6 +123,41 @@ def floorplan():
     show_default=True,
     help="Map: Value for cells to be considered free in the occupancy map",
 )
+@click.option(
+    "--keyframe-start",
+    type=click.INT,
+    default=0,
+    show_default=True,
+    help="Timestamp of the first keyframe",
+)
+@click.option(
+    "--keyframe-end",
+    type=click.INT,
+    default=180,
+    show_default=True,
+    help="Timestamp of the last keyframe",
+)
+@click.option(
+    "--keyframe-start-state",
+    type=click.FLOAT,
+    default=0.0,
+    show_default=True,
+    help="Start joint angle of the doors",
+)
+@click.option(
+    "--keyframe-sampling-interval",
+    type=click.INT,
+    default=30,
+    show_default=True,
+    help="Sampling interval",
+)
+@click.option(
+    "--keyframe-state-change-probability",
+    type=click.FLOAT,
+    default=0.5,
+    show_default=True,
+    help="Probability of a door changing states at the next interval",
+)
 def generate(inputs, output_path, **kwargs):
     print(kwargs)
 
@@ -137,6 +173,7 @@ def generate(inputs, output_path, **kwargs):
     get_3d_mesh(g, output_path, **kwargs)
 
     get_polyline_floorplan(g, output_path, **kwargs)
+    get_keyframes(output_path, **kwargs)
 
 
 if __name__ == "__main__":

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -10,6 +10,19 @@ from fpm.generators.polyline import get_polyline_floorplan
 from fpm.generators.door_keyframes import get_keyframes
 
 
+def configure(ctx, param, filename):
+    if not filename:
+        return
+    import tomllib
+
+    ctx.default_map = dict()
+    with open(filename, "rb") as f:
+        data = tomllib.load(f)
+
+    cmd_defaults = data.get("generate", {})
+    ctx.default_map.update(cmd_defaults)
+
+
 @click.group()
 def floorplan():
     pass
@@ -40,6 +53,16 @@ def floorplan():
     type=click.Path(exists=True, resolve_path=True),
     default=os.path.join("."),
     help="Path with Jinja templates",
+)
+@click.option(
+    "-c",
+    "--config",
+    type=click.Path(dir_okay=False),
+    is_eager=True,
+    expose_value=False,
+    help="Read values from TOML config file",
+    show_default=True,
+    callback=configure,
 )
 def generate(ctx, inputs, **kwargs):
 

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -86,7 +86,7 @@ def mesh(ctx, **kwargs):
 @generate.command()
 @click.pass_context
 @click.option(
-    "--waypoint-dist-to-corner",
+    "--dist-to-corner",
     type=click.FLOAT,
     default=0.7,
     show_default=True,
@@ -122,67 +122,67 @@ def gazebo(ctx, **kwargs):
 @generate.command()
 @click.pass_context
 @click.option(
-    "--map-laser-height",
+    "--laser-height",
     type=click.FLOAT,
     default=0.7,
     show_default=True,
-    help="Map: Height of the laser to generate the occupancy grid",
+    help="Height of the laser to generate the occupancy grid",
 )
 @click.option(
-    "--map-border",
+    "--border",
     type=click.INT,
     default=50,
     show_default=True,
-    help="Map: Border the occupancy grid",
+    help="Border the occupancy grid image file",
 )
 @click.option(
-    "--map-resolution",
+    "--resolution",
     type=click.FLOAT,
     default=0.05,
     show_default=True,
-    help="Map: Resolution of the pgm file in m/pixel",
+    help="Resolution of the pgm file in m/pixel",
 )
 @click.option(
-    "--map-occupied-threshold",
+    "--occupied-threshold",
     type=click.FLOAT,
     default=0.65,
     show_default=True,
-    help="Map: Probability of a pixel at which a cell is considered occupied",
+    help="Probability of a pixel at which a cell is considered occupied",
 )
 @click.option(
-    "--map-free-threshold",
+    "--free-threshold",
     type=click.FLOAT,
     default=0.196,
     show_default=True,
-    help="Map: Probability of a pixel at which a cell is considered free",
+    help="Probability of a pixel at which a cell is considered free",
 )
 @click.option(
-    "--map-negate",
-    type=click.FLOAT,
-    default=0.0,
-    show_default=True,
-    help="Map: Whether the occupied/free/unknown semantics of the occupancy grid should be reversed",
-)
-@click.option(
-    "--map-unknown-value",
-    type=click.INT,
-    default=200,
-    show_default=True,
-    help="Map: Value for cells to be considered unknown in the occupancy grid",
-)
-@click.option(
-    "--map-occupied-value",
+    "--negate",
     type=click.INT,
     default=0,
     show_default=True,
-    help="Map: Value for cells to be considered occupied in the occupancy map",
+    help="Whether the occupied/free/unknown semantics of the occupancy grid should be reversed",
 )
 @click.option(
-    "--map-free-value",
+    "--unknown-value",
+    type=click.INT,
+    default=200,
+    show_default=True,
+    help="Value for cells to be considered unknown in the occupancy grid",
+)
+@click.option(
+    "--occupied-value",
+    type=click.INT,
+    default=0,
+    show_default=True,
+    help="Value for cells to be considered occupied in the occupancy map",
+)
+@click.option(
+    "--free-value",
     type=click.INT,
     default=255,
     show_default=True,
-    help="Map: Value for cells to be considered free in the occupancy map",
+    help="Value for cells to be considered free in the occupancy map",
 )
 def occ_grid(ctx, **kwargs):
     """Generate the occupancy grid map of the floorplan"""
@@ -199,35 +199,36 @@ def polyline(ctx, **kwargs):
 @generate.command()
 @click.pass_context
 @click.option(
-    "--keyframe-start",
+    "--start-frame",
     type=click.INT,
     default=0,
     show_default=True,
     help="Timestamp of the first keyframe",
 )
 @click.option(
-    "--keyframe-end",
+    "--end-frame",
     type=click.INT,
     default=180,
     show_default=True,
     help="Timestamp of the last keyframe",
 )
 @click.option(
-    "--keyframe-start-state",
+    "--start-state",
     type=click.FLOAT,
     default=0.0,
     show_default=True,
     help="Start joint angle of the doors",
 )
 @click.option(
-    "--keyframe-sampling-interval",
+    "--sampling-interval",
     type=click.INT,
     default=30,
     show_default=True,
     help="Sampling interval",
 )
 @click.option(
-    "--keyframe-state-change-probability",
+    "--state-change-probability",
+    "--state-change-prob",
     type=click.FLOAT,
     default=0.5,
     show_default=True,

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -28,7 +28,7 @@ def floorplan():
     pass
 
 
-@floorplan.group()
+@floorplan.group(chain=True)
 @click.pass_context
 @click.option(
     "-i",

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -3,7 +3,7 @@ import click
 
 from fpm.graph import build_graph_from_directory, get_floorplan_model_name
 from fpm.generators.gazebo import gazebo_world, door_object_models
-from fpm.generators.tasks import tasks
+from fpm.generators.tasks import get_tasks
 from fpm.generators.occ_grid import get_occ_grid
 from fpm.generators.mesh import get_3d_mesh
 from fpm.generators.polyline import get_polyline_floorplan
@@ -164,7 +164,7 @@ def generate(inputs, output_path, **kwargs):
     g = build_graph_from_directory(inputs)
     model_name = get_floorplan_model_name(g)
 
-    tasks(g, output_path, **kwargs)
+    get_tasks(g, output_path, **kwargs)
 
     door_object_models(g, output_path, **kwargs)
     gazebo_world(g, model_name, output_path, **kwargs)

--- a/src/fpm/cli.py
+++ b/src/fpm/cli.py
@@ -18,18 +18,19 @@ def floorplan():
 @floorplan.group()
 @click.pass_context
 @click.option(
+    "-i",
     "--inputs",
     "--input-path",
-    "-i",
     type=click.Path(exists=True, resolve_path=True),
     required=True,
     multiple=True,
     help="Path with JSON-LD models to be used as inputs",
 )
 @click.option(
-    "--output-path",
     "-o",
     "--outputs",
+    "--output-path",
+    "base_path",
     type=click.Path(exists=True, resolve_path=True),
     default=os.path.join("."),
     help="Output path for generated artefacts",
@@ -40,27 +41,23 @@ def floorplan():
     default=os.path.join("."),
     help="Path with Jinja templates",
 )
-def generate(ctx, inputs, output_path, **kwargs):
+def generate(ctx, inputs, **kwargs):
+
     print(kwargs)
 
     g = build_graph_from_directory(inputs)
     model_name = get_floorplan_model_name(g)
 
     ctx.ensure_object(dict)
-    ctx.obj[model_name] = model_name
-    ctx.obj["graph"] = g
-
-    print("End of generate command")
+    ctx.obj["model_name"] = model_name
+    ctx.obj["g"] = g
 
 
 @generate.command()
 @click.pass_context
 def mesh(ctx, **kwargs):
-    print("test")
-    print(ctx.obj)
-    print(kwargs)
-    g = ctx.obj["graph"]
-    # get_3d_mesh(g, output_path, **kwargs)
+    """Generate a 3D-mesh in STL or gltF 2.0 format"""
+    get_3d_mesh(**ctx.obj, **ctx.parent.params, **kwargs)
 
 
 @generate.command()
@@ -73,8 +70,8 @@ def mesh(ctx, **kwargs):
     help="Distance between generated waypoints and a space's corner",
 )
 def tasks(ctx, **kwargs):
-    g = ctx.obj["graph"]
-    # get_tasks(g, output_path, **kwargs)
+    """Generate disinfection tasks for each room in the floorplan"""
+    get_tasks(**ctx.obj, **ctx.parent.params, **kwargs)
 
 
 @generate.command()
@@ -94,9 +91,9 @@ def tasks(ctx, **kwargs):
     help="Name of the ROS package where gazebo models",
 )
 def gazebo(ctx, **kwargs):
-    g = ctx.obj["graph"]
-    # door_object_models(g, output_path, **kwargs)
-    # gazebo_world(g, model_name, output_path, **kwargs)
+    """Generate Gazebo world, models and launch files"""
+    door_object_models(**ctx.obj, **ctx.parent.params, **kwargs)
+    gazebo_world(**ctx.obj, **ctx.parent.params, **kwargs)
 
 
 @generate.command()
@@ -165,15 +162,15 @@ def gazebo(ctx, **kwargs):
     help="Map: Value for cells to be considered free in the occupancy map",
 )
 def occ_grid(ctx, **kwargs):
-    g = ctx.obj["graph"]
-    # get_occ_grid(g, output_path, **kwargs)
+    """Generate the occupancy grid map of the floorplan"""
+    get_occ_grid(**ctx.obj, **ctx.parent.params, **kwargs)
 
 
 @generate.command()
 @click.pass_context
 def polyline(ctx, **kwargs):
-    g = ctx.obj["graph"]
-    # get_polyline_floorplan(g, output_path, **kwargs)
+    """Generate a 3D polyline representation of the floorplan"""
+    get_polyline_floorplan(**ctx.obj, **ctx.parent.params, **kwargs)
 
 
 @generate.command()
@@ -214,8 +211,8 @@ def polyline(ctx, **kwargs):
     help="Probability of a door changing states at the next interval",
 )
 def door_keyframes(ctx, **kwargs):
-    g = ctx.obj["graph"]
-    # get_keyframes(output_path, **kwargs)
+    """Generate the sampled keyframes for doors with time-based behaviours"""
+    get_keyframes(**ctx.obj, **ctx.parent.params, **kwargs)
 
 
 if __name__ == "__main__":

--- a/src/fpm/generators/door_keyframes.py
+++ b/src/fpm/generators/door_keyframes.py
@@ -1,0 +1,33 @@
+import random
+import json
+
+
+def get_keyframes(i):
+
+    min_time = 90
+    max_time = 730
+    current_state = 0
+    p_change = 0.5
+    interval = 30
+
+    keyframes = [{"pose": current_state, "time": 0.0}]
+
+    for t in range(min_time, max_time, interval):
+
+        # sample the distribution to determine if we change the current state
+        value = random.random()
+
+        if value <= p_change:
+            current_state = 1.7 if current_state == 0 else 0
+            keyframes.append(
+                {"pose": current_state, "time": t + int(random.random() * 10)}
+            )
+
+    return keyframes
+
+
+if __name__ == "__main__":
+
+    for i in range(11):
+        with open("output/keyframes_door_{i}.json".format(i=i), "w") as output:
+            output.write(json.dumps({"keyframes": get_keyframes(i)}, indent=4))

--- a/src/fpm/generators/door_keyframes.py
+++ b/src/fpm/generators/door_keyframes.py
@@ -1,33 +1,51 @@
 import random
-import json
+
+from fpm.utils import get_output_path, save_file
 
 
-def get_keyframes(i):
+def generate_door_keyframes(keyframe_start, keyframe_end, **kwargs):
 
-    min_time = 90
-    max_time = 730
-    current_state = 0
-    p_change = 0.5
-    interval = 30
+    current_state = kwargs.get("keyframe_start_state")
+    interval = kwargs.get("keyframe_sampling_interval")
+    p_change = kwargs.get("keyframe_state_change_probability")
 
     keyframes = [{"pose": current_state, "time": 0.0}]
 
-    for t in range(min_time, max_time, interval):
-
-        # sample the distribution to determine if we change the current state
-        value = random.random()
-
-        if value <= p_change:
-            current_state = 1.7 if current_state == 0 else 0
-            keyframes.append(
-                {"pose": current_state, "time": t + int(random.random() * 10)}
-            )
+    for t in range(keyframe_start, keyframe_end, interval):
+        # TODO Simplify the sampling of states and timestamps
+        current_state = sample_door_state_open_close(p_change, current_state)
+        time_delta = sample_time_delta()
+        keyframes.append({"pose": current_state, "time": t + time_delta})
 
     return keyframes
 
 
-if __name__ == "__main__":
+def sample_time_delta():
+    # TODO Why are timestamps integers?
+    return int(random.random() * 10)
 
-    for i in range(11):
-        with open("output/keyframes_door_{i}.json".format(i=i), "w") as output:
-            output.write(json.dumps({"keyframes": get_keyframes(i)}, indent=4))
+
+def sample_door_state_open_close(
+    p_change, current_state, open_angle=1.7, closed_angle=0.0
+):
+    # sample the distribution to determine if we change the current state
+    value = random.random()
+    if value <= p_change:
+        if current_state == closed_angle:
+            state = open_angle
+        else:
+            state = closed_angle
+    else:
+        state = current_state
+
+    return state
+
+
+def get_keyframes(base_path, **kwargs):
+    output_path = get_output_path(base_path, "doors/behaviours/keyframes")
+    num_doors = kwargs.get("keyframes_num_doors", 11)
+    for i in range(num_doors):
+        keyframes = generate_door_keyframes(**kwargs)
+        file_name = "keyframes_door_{}.json".format(i)
+        contents = {"keyframes": keyframes}
+        save_file(output_path, file_name, contents)

--- a/src/fpm/generators/door_keyframes.py
+++ b/src/fpm/generators/door_keyframes.py
@@ -3,15 +3,15 @@ import random
 from fpm.utils import get_output_path, save_file
 
 
-def generate_door_keyframes(keyframe_start, keyframe_end, **kwargs):
+def generate_door_keyframes(start_frame, end_frame, **kwargs):
 
-    current_state = kwargs.get("keyframe_start_state")
-    interval = kwargs.get("keyframe_sampling_interval")
-    p_change = kwargs.get("keyframe_state_change_probability")
+    current_state = kwargs.get("start_state")
+    interval = kwargs.get("sampling_interval")
+    p_change = kwargs.get("state_change_probability")
 
     keyframes = [{"pose": current_state, "time": 0.0}]
 
-    for t in range(keyframe_start, keyframe_end, interval):
+    for t in range(start_frame, end_frame, interval):
         # TODO Simplify the sampling of states and timestamps
         current_state = sample_door_state_open_close(p_change, current_state)
         time_delta = sample_time_delta()
@@ -43,7 +43,7 @@ def sample_door_state_open_close(
 
 def get_keyframes(base_path, **kwargs):
     output_path = get_output_path(base_path, "doors/behaviours/keyframes")
-    num_doors = kwargs.get("keyframes_num_doors", 11)
+    num_doors = kwargs.get("num_doors", 11)
     for i in range(num_doors):
         keyframes = generate_door_keyframes(**kwargs)
         file_name = "keyframes_door_{}.json".format(i)

--- a/src/fpm/generators/gazebo.py
+++ b/src/fpm/generators/gazebo.py
@@ -71,7 +71,7 @@ def gazebo_world_model(g, model_name, base_path, **kwargs):
     model = {"instances": instances, "name": model_name}
 
     output_path = get_output_path(base_path, "gazebo/worlds")
-    if kwargs.get("ros_version", "ros2") == "ros2":
+    if kwargs.get("ros_version", "ROS2") == "ROS2":
         file_name = "{name}.sdf".format(name=model_name)
     else:
         file_name = "{name}.world".format(name=model_name)

--- a/src/fpm/generators/occ_grid.py
+++ b/src/fpm/generators/occ_grid.py
@@ -194,19 +194,14 @@ def get_2d_shape(west, south, resolution, border, points=None, shape=None):
 
 def save_map_metadata(output_path, map_name, center, **custom_args):
     file_name = "{}.yaml".format(map_name)
-    negate = custom_args.get("map_negate", 0)
-    resolution = custom_args.get("map_resolution", 0.05)
-    occupied_thresh = custom_args.get("map_occupied_threshold", 0.65)
-    free_thresh = custom_args.get("map_free_threshold", 0.196)
-    laser_height = custom_args.get("map_laser_height", 0.7)
     map_metadata = {
-        "resolution": resolution,
+        "resolution": custom_args.get("resolution", 0.05),
         "origin": center,
-        "occupied_thresh": occupied_thresh,
-        "free_thresh": free_thresh,
-        "negate": negate,
+        "occupied_thresh": custom_args.get("occupied_threshold", 0.65),
+        "free_thresh": custom_args.get("free_threshold", 0.196),
+        "negate": custom_args.get("negate", 0),
         "image": "{}.pgm".format(map_name),
-        "laser_height": laser_height,
+        "laser_height": custom_args.get("laser_height", 0.7),
     }
 
     save_file(output_path, file_name, map_metadata)

--- a/src/fpm/generators/ros.py
+++ b/src/fpm/generators/ros.py
@@ -17,7 +17,7 @@ def gazebo_world_launch(model_name, base_path, **kwargs):
     template_path = kwargs.get("template_path")
     output_path = get_output_path(base_path, "ros/launch")
 
-    if kwargs.get("ros_version", "ros2") == "ros2":
+    if kwargs.get("ros_version", "ROS2") == "ROS2":
         file_name = "{name}.ros2.launch".format(name=model_name)
         template_name = "ros/world.ros2.launch.jinja"
     else:

--- a/src/fpm/generators/tasks.py
+++ b/src/fpm/generators/tasks.py
@@ -11,8 +11,8 @@ def generate_task_specification(model, output_path, **custom_args):
 
 def get_tasks(g, base_path, **kwargs):
     output_path = get_output_path(base_path, "tasks")
-    inset_width = kwargs.get("waypoint_dist_to_corner")
+    dist_to_corner = kwargs.get("dist_to_corner")
 
-    tasks = get_all_disinfection_tasks(g, inset_width)
+    tasks = get_all_disinfection_tasks(g, dist_to_corner)
     for task in tasks:
         generate_task_specification(task, output_path)

--- a/src/fpm/generators/tasks.py
+++ b/src/fpm/generators/tasks.py
@@ -1,16 +1,15 @@
-import yaml
 from fpm.transformations.tasks import get_all_disinfection_tasks
 
 from fpm.utils import save_file, get_output_path
 
 
 def generate_task_specification(model, output_path, **custom_args):
-    file_name = "{}_task.yaml".format(model.get("id"))
+    file_name = "{}_route.yaml".format(model.get("id"))
     save_file(output_path, file_name, model)
 
 
-def get_tasks(g, base_path, **kwargs):
-    output_path = get_output_path(base_path, "tasks")
+def get_disinfection_tasks(g, base_path, **kwargs):
+    output_path = get_output_path(base_path, "tasks/disinfection")
     dist_to_corner = kwargs.get("dist_to_corner")
 
     tasks = get_all_disinfection_tasks(g, dist_to_corner)

--- a/src/fpm/generators/tasks.py
+++ b/src/fpm/generators/tasks.py
@@ -9,7 +9,7 @@ def generate_task_specification(model, output_path, **custom_args):
     save_file(output_path, file_name, model)
 
 
-def tasks(g, base_path, **kwargs):
+def get_tasks(g, base_path, **kwargs):
     output_path = get_output_path(base_path, "tasks")
     inset_width = kwargs.get("waypoint_dist_to_corner")
 

--- a/src/fpm/utils.py
+++ b/src/fpm/utils.py
@@ -2,6 +2,7 @@ import os
 import tomllib
 
 import yaml
+import json
 import bpy
 
 import numpy as np
@@ -34,6 +35,9 @@ def save_file(output_path, file_name, contents):
     if ext in [".yaml"]:
         with open(output_file, "w") as f:
             yaml.dump(contents, f, default_flow_style=None)
+    elif ext == ".json":
+        with open(output_file, "w") as f:
+            json.dump(contents, f, indent=4)
     elif ext in [".pgm", ".jpg"]:
         contents.save(output_file, quality=95)
     elif ext in [".stl"]:


### PR DESCRIPTION
This PR introduces breaking changes in the CLI. The changes allow to: 

- generate a single or a subset of artefacts by invoking individual commands. To generate all artefacts as in the previous version one must pass all the commands.
- use a configuration file instead of passing individual arguments to each command

The output of `floorplan generate --help` now shows the individual commands:

```
Usage: floorplan generate [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...

Options:
  -i, --inputs, --input-path PATH
                                  Path with JSON-LD models to be used as
                                  inputs  [required]
  -o, --outputs, --output-path PATH
                                  Output path for generated artefacts
  --templates PATH                Path with Jinja templates
  -c, --config FILE               Read values from TOML config file
  --help                          Show this message and exit.

Commands:
  door-keyframes  Generate the sampled keyframes for doors with...
  gazebo          Generate Gazebo world, models and launch files
  mesh            Generate a 3D-mesh in STL or gltF 2.0 format
  occ-grid        Generate the occupancy grid map of the floorplan
  polyline        Generate a 3D polyline representation of the floorplan
  tasks           Generate disinfection tasks for each room in the floorplan
```

## Others

It also fixes the `negate` parameter of the occupancy grid metadata.